### PR TITLE
Add ns annotation inheritance to pods (#6002) (#6002)

### DIFF
--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -1,0 +1,239 @@
+[
+  {
+    "op": "add",
+    "path": "/metadata/annotations/config.alpha.linkerd.io~1proxy-wait-before-exit-seconds",
+    "value": "300"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/config.linkerd.io~1skip-outbound-ports",
+    "value": "34567"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/linkerd.io~1identity-mode",
+    "value": "disabled"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/linkerd.io~1proxy-version",
+    "value": "dev-undefined"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/linkerd.io~1control-plane-ns",
+    "value": "linkerd"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/linkerd.io~1proxy-deployment",
+    "value": "owner-deployment"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/linkerd.io~1workload-ns",
+    "value": "kube-public"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": []
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": []
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "emptyDir": {},
+      "name": "linkerd-proxy-init-xtables-lock"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/-",
+    "value": {
+      "args": [
+        "--incoming-proxy-port",
+        "4143",
+        "--outgoing-proxy-port",
+        "4140",
+        "--proxy-uid",
+        "2102",
+        "--inbound-ports-to-ignore",
+        "4190,4191",
+        "--outbound-ports-to-ignore",
+        "34567"
+      ],
+      "image": "cr.l5d.io/linkerd/proxy-init:v1.3.11",
+      "imagePullPolicy": "IfNotPresent",
+      "name": "linkerd-init",
+      "resources": {
+        "limits": {
+          "cpu": "100m",
+          "memory": "50Mi"
+        },
+        "requests": {
+          "cpu": "10m",
+          "memory": "10Mi"
+        }
+      },
+      "securityContext": {
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "add": [
+            "NET_ADMIN",
+            "NET_RAW"
+          ]
+        },
+        "privileged": false,
+        "readOnlyRootFilesystem": true,
+        "runAsNonRoot": false,
+        "runAsUser": 0
+      },
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "volumeMounts": [
+        {
+          "mountPath": "/run",
+          "name": "linkerd-proxy-init-xtables-lock"
+        }
+      ]
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/-",
+    "value": {
+      "env": [
+        {
+          "name": "LINKERD2_PROXY_LOG",
+          "value": "warn,linkerd=info"
+        },
+        {
+          "name": "LINKERD2_PROXY_LOG_FORMAT",
+          "value": "plain"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_SVC_ADDR",
+          "value": "linkerd-dst-headless.linkerd.svc.cluster.local.:8086"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_PROFILE_NETWORKS",
+          "value": "10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT",
+          "value": "100ms"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT",
+          "value": "1000ms"
+        },
+        {
+          "name": "LINKERD2_PROXY_CONTROL_LISTEN_ADDR",
+          "value": "0.0.0.0:4190"
+        },
+        {
+          "name": "LINKERD2_PROXY_ADMIN_LISTEN_ADDR",
+          "value": "0.0.0.0:4191"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR",
+          "value": "127.0.0.1:4140"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_LISTEN_ADDR",
+          "value": "0.0.0.0:4143"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES",
+          "value": "svc.cluster.local."
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE",
+          "value": "10000ms"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE",
+          "value": "10000ms"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION",
+          "value": "25,443,587,3306,5432,11211"
+        },
+        {
+          "name": "_pod_ns",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "metadata.namespace"
+            }
+          }
+        },
+        {
+          "name": "_pod_nodeName",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "spec.nodeName"
+            }
+          }
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_CONTEXT",
+          "value": "{\"ns\":\"$(_pod_ns)\", \"nodeName\":\"$(_pod_nodeName)\"}\n"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_DISABLED",
+          "value": "disabled"
+        }
+      ],
+      "image": "cr.l5d.io/linkerd/proxy:dev-undefined",
+      "imagePullPolicy": "IfNotPresent",
+      "lifecycle": {
+        "preStop": {
+          "exec": {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "sleep 300"
+            ]
+          }
+        }
+      },
+      "livenessProbe": {
+        "httpGet": {
+          "path": "/live",
+          "port": 4191
+        },
+        "initialDelaySeconds": 10
+      },
+      "name": "linkerd-proxy",
+      "ports": [
+        {
+          "containerPort": 4143,
+          "name": "linkerd-proxy"
+        },
+        {
+          "containerPort": 4191,
+          "name": "linkerd-admin"
+        }
+      ],
+      "readinessProbe": {
+        "httpGet": {
+          "path": "/ready",
+          "port": 4191
+        },
+        "initialDelaySeconds": 2
+      },
+      "resources": null,
+      "securityContext": {
+        "allowPrivilegeEscalation": false,
+        "readOnlyRootFilesystem": true,
+        "runAsUser": 2102
+      },
+      "terminationMessagePolicy": "FallbackToLogsOnError"
+    }
+  }
+]

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -267,6 +267,7 @@ func TestGetOverriddenValues(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			resourceConfig.AppendNamespaceAnnotations()
 			actual, err := resourceConfig.GetOverriddenValues()
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Closes #5977  

## What

This changes adds support for namespace configuration annotation inheritance for pods. Any annotations (e.g `config.linkerd.io/skip-outbound-ports` or `config.linkerd.io/proxy-await`) that are applied against a namespace will now also be applied to pods running in that namespace by the _proxy-injector_. 

* Pods do not inherit annotations from their namespaces; the exception to this is `opaque-ports` introduced in #5941. This expands on the work by allowing all config annotations to be inherited.
* Main advantage here is that instead of applying annotations on a workload-by-workload basis we can just apply them against the namespace and it will be mirrored on all pods within the namespace.
* Through this change the controller can also check the proxy's configuration directly from the pod's meta rather than from env variables.

## How

Change is pretty straightforward. We want to make sure that before we apply a JSON patch we first copy all of the namespace annotations to the pod. The logic that was in place takes care of applying the patch.

* One obvious constraint is that we want only want valid configuration annotations to be applied. To be a "valid" configuration it has to exist and it has to be prefixed with `config.linkerd.io` -- the easiest way to do this is to go through all of the available proxy configuration options and check whether any of the options are included in the namespace's annotations (done in `GetNsConfigKeys()` where we fetch all annotation keys from the namespace).
* A consideration I had with this change is whether to add `opaque-ports` as part of all of the config keys; opaque ports is a bit different though since it can be applied on a pod as well as a service -- through this change we only want to apply config annotations to pods. I chose to keep the two separate.
* Added a unit test that checks if a pod inherits config annotations from its namespace; this also includes an invalid annotation which doesn't show up in the "expected" patch to test we validate configuration correctly.

### Tests
---

I injected emojivoto and added an annotation to its namespace:

```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    config.linkerd.io/opaque-ports: "34567"
    config.linkerd.io/proxy-log-level: debug
    config.linkerd.io/skip-outbound-ports: "44556"
    linkerd.io/inject: enabled
```

The deployment specs do not have any additional annotations as part of the pod template metadata. I first tested if the above annotations would be inherited with the current edge release (I expected opaque ports to be).

**Before changes**:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    config.linkerd.io/opaque-ports: "34567"
    linkerd.io/created-by: linkerd/proxy-injector edge-21.4.1
    linkerd.io/identity-mode: default
    linkerd.io/inject: enabled
    linkerd.io/proxy-version: edge-21.4.1
  creationTimestamp: "2021-04-08T14:33:10Z"
  generateName: emoji-696d9d8f95-
  labels:
    app: emoji-svc
    linkerd.io/control-plane-ns: linkerd
    linkerd.io/proxy-deployment: emoji
    linkerd.io/workload-ns: emojivoto
    pod-template-hash: 696d9d8f95
    version: v11
spec:
  initContainers:
  - args:
    - --incoming-proxy-port
    - "4143"
    - --outgoing-proxy-port
    - "4140"
    - --proxy-uid
    - "2102"
    - --inbound-ports-to-ignore
    - 4190,4191
    - --outbound-ports-to-ignore
    - "44556"
    image: cr.l5d.io/linkerd/proxy-init:v1.3.9
    imagePullPolicy: IfNotPresent
    name: linkerd-init
```
(opaque ports is in there, skip outbound isn't -- although the initContainer gets the right argument since this is already applied from the namespace by the proxy injector).

**After the changes**:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    config.linkerd.io/opaque-ports: "34567"
    config.linkerd.io/proxy-log-level: debug
    config.linkerd.io/skip-outbound-ports: "44556"
    linkerd.io/created-by: linkerd/proxy-injector dev-a7bb62fd-matei
    linkerd.io/identity-mode: default
    linkerd.io/inject: enabled
    linkerd.io/proxy-version: dev-a7bb62fd-matei
  creationTimestamp: "2021-04-08T14:42:06Z"
  generateName: web-5f86686c4d-
  labels:
    app: web-svc
    linkerd.io/control-plane-ns: linkerd
    linkerd.io/proxy-deployment: web
    linkerd.io/workload-ns: emojivoto
    pod-template-hash: 5f86686c4d
    version: v11
  initContainers:
  - args:
    - --incoming-proxy-port
    - "4143"
    - --outgoing-proxy-port
    - "4140"
    - --proxy-uid
    - "2102"
    - --inbound-ports-to-ignore
    - 4190,4191
    - --outbound-ports-to-ignore
    - "44556"
    image: cr.l5d.io/linkerd/proxy-init:v1.3.9
    imagePullPolicy: IfNotPresent
    name: linkerd-init
```
(opaque ports is there and so is skip outbound and the proxy log level, correct options still passed to the initContainers).

*Edit*: made a small change, had a look at `GetNsConfigKeys()` and thought it'd be better to keep the slice of keys as a fixed length array since we know there will be at most `len(ProxyAnnotations)` at any point. Not sure such a big size is warranted but we can avoid calling append for every element.

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
